### PR TITLE
Add SSL Verify Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ import (
 
 function main() {
         client, _ := netscaler.NewNitroClientFromEnv()
-
-        // Option to disable SSL validation
-        client.DisableSSLVerify()
-
         lb1 := lb.Lbvserver{
                 Name:        "sample_lb",
                 Ipv46:       "10.71.136.50",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instantiate a client using `NewNitroClient`. To initialize the client from envir
 export NS_URL=http://<ip-address>
 export NS_LOGIN=<netscaler-username>
 export NS_PASSWORD=<netscaler-password>
-export NS_SSLVERIFY=<bool>
+export NS_SSLVERIFY=<bool>(optional)
 ```
 
 Config object types can be passed in as strings ("lbvserver"), or looked up from `netscaler.<config object type>.Type()`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Instantiate a client using `NewNitroClient`. To initialize the client from envir
 export NS_URL=http://<ip-address>
 export NS_LOGIN=<netscaler-username>
 export NS_PASSWORD=<netscaler-password>
+export NS_SSLVERIFY=<bool>
 ```
 
 Config object types can be passed in as strings ("lbvserver"), or looked up from `netscaler.<config object type>.Type()`
@@ -28,6 +29,10 @@ import (
 
 function main() {
         client, _ := netscaler.NewNitroClientFromEnv()
+
+        // Option to disable SSL validation
+        client.DisableSSLVerify()
+
         lb1 := lb.Lbvserver{
                 Name:        "sample_lb",
                 Ipv46:       "10.71.136.50",

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -35,7 +35,7 @@ type NitroClient struct {
 }
 
 //NewNitroClient returns a usable NitroClient. Does not check validity of supplied parameters
-func NewNitroClient(url string, username string, password string, bool sslverify) *NitroClient {
+func NewNitroClient(url string, username string, password string, sslverify bool) *NitroClient {
 	c := new(NitroClient)
 	c.url = strings.Trim(url, " /") + "/nitro/v1/config/"
 	c.username = username

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"os"
 	"strings"
+	"strconv"
 )
 
 //NitroClient has methods to configure the NetScaler
@@ -55,7 +56,7 @@ func NewNitroClient(url string, username string, password string, sslverify bool
 	return c
 }
 
-func NewProxyingNitroClient(url string, username string, password string, proxiedNsIp string, bool sslverify) *NitroClient {
+func NewProxyingNitroClient(url string, username string, password string, proxiedNsIp string, sslverify bool) *NitroClient {
 	c := new(NitroClient)
 	c.url = strings.Trim(url, " /") + "/nitro/v1/config/"
 	c.username = username
@@ -105,12 +106,12 @@ func NewNitroClientFromEnv(args ...string) (*NitroClient, error) {
 			return nil, fmt.Errorf("Could not determine NetScaler password: NS_PASSWORD not set or passed in as third parameter")
 		}
 	}
-	password := os.Getenv("NS_SSLVERIFY")
-	if sslverify == "" {
+	sslverify, err := strconv.ParseBool(os.Getenv("NS_SSLVERIFY"))
+	if err != nil  {
 		if argslen >= 4 {
 			url = args[3]
 		} else {
-			return nil, fmt.Errorf("Could not determine ssl verification: NS_SSLVERIFY not set or passed in as third parameter")
+			return nil, fmt.Errorf("Could not convert SSL vefification type to true or false: NS_SSLVERIFY not set properly or passed in as fourth parameter")
 		}
 	}
 	proxiedNs := os.Getenv("_MPS_API_PROXY_MANAGED_INSTANCE_IP")


### PR DESCRIPTION
This change adds a DisableSSLVerify() function to disable SSL validation for endpoints which are not using valid certificates.  The default behavior is to always check.