### PR TITLE
Avoid displaying systemfile contents

### DIFF
--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -41,8 +41,9 @@ func (c *NitroClient) AddResource(resourceType string, name string, resourceStru
 
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
-
+	if resourceType != "systemfile" {
+		log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
+	}
 	body, err := c.createResource(resourceType, resourceJSON)
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] go-nitro: Failed to create resource of type %s, name=%s, err=%s", resourceType, name, err)

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -41,7 +41,7 @@ func (c *NitroClient) AddResource(resourceType string, name string, resourceStru
 
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	if resourceType != "systemfile" {
+	if !strings.EqualFold(resourceType, "systemfile") {
 		log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
 	}
 	body, err := c.createResource(resourceType, resourceJSON)


### PR DESCRIPTION
If  resource type is Systemfile, the resource json should not be displayed in log