### PR TITLE
Allow for actOnResource to take empty action

### DIFF
--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -766,3 +766,19 @@ func TestDesiredStateServicegroupAPI(t *testing.T) {
 	}
 
 }
+
+func TestNullAction(t *testing.T) {
+	reboot := ns.Reboot{
+		Warm: true,
+	}
+
+	err := client.ActOnResource("reboot", &reboot, "")
+	if err != nil {
+		t.Error("Could not make null action reboot", err)
+		log.Println("Cannot continue")
+		return
+	}
+
+	// Add a timeout to wait for instance to be back online
+	time.Sleep(60 * time.Second)
+}

--- a/netscaler/netscaler_resource.go
+++ b/netscaler/netscaler_resource.go
@@ -154,7 +154,12 @@ func (c *NitroClient) applyResource(resourceType string, resourceJSON []byte) ([
 func (c *NitroClient) actOnResource(resourceType string, resourceJSON []byte, action string) ([]byte, error) {
 	log.Println("[DEBUG] go-nitro: changing resource of type ", resourceType)
 
-	url := c.url + fmt.Sprintf("%s?action=%s", resourceType, action)
+	var url string
+	if action == "" {
+		url = c.url + fmt.Sprintf("%s", resourceType)
+	} else {
+		url = c.url + fmt.Sprintf("%s?action=%s", resourceType, action)
+	}
 	log.Println("[TRACE] go-nitro: url is ", url)
 
 	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)


### PR DESCRIPTION
Allow for empty action.

This is needed to successfully implement the reboot ADC action.

The request should be formed like so

```
POST URL: http://nsip/nitro/v1/config/reboot
POST BODY: { reboot { warm: true}}
```