### PR TITLE
Token-based authentication support 

### DIFF
--- a/example/lbvserver.go
+++ b/example/lbvserver.go
@@ -18,9 +18,9 @@ package main
 import (
 	"log"
 
-	"github.com/imkritesh/go-nitro/config/basic"
-	"github.com/imkritesh/go-nitro/config/lb"
-	"github.com/imkritesh/go-nitro/netscaler"
+	"github.com/chiradeep/go-nitro/config/basic"
+	"github.com/chiradeep/go-nitro/config/lb"
+	"github.com/chiradeep/go-nitro/netscaler"
 )
 
 func main() {

--- a/example/lbvserver.go
+++ b/example/lbvserver.go
@@ -18,9 +18,9 @@ package main
 import (
 	"log"
 
-	"github.com/chiradeep/go-nitro/config/basic"
-	"github.com/chiradeep/go-nitro/config/lb"
-	"github.com/chiradeep/go-nitro/netscaler"
+	"github.com/imkritesh/go-nitro/config/basic"
+	"github.com/imkritesh/go-nitro/config/lb"
+	"github.com/imkritesh/go-nitro/netscaler"
 )
 
 func main() {
@@ -29,6 +29,7 @@ func main() {
 		log.Fatal("Could not create a client: ", err)
 	}
 	log.Printf("Client is %+v\n", *client)
+	client.Login()
 	lb1 := lb.Lbvserver{
 		Name:        "sample_lb",
 		Ipv46:       "10.71.136.50",
@@ -68,5 +69,6 @@ func main() {
 
 	client.EnableFeatures([]string{"CS"})
 	client.SaveConfig()
+	client.Logout()
 
 }

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -44,6 +44,8 @@ type NitroClient struct {
 	password  string
 	proxiedNs string
 	client    *http.Client
+	sessionid string
+	timeout   int
 }
 
 //NewNitroClient returns a usable NitroClient. Does not check validity of supplied parameters

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 //NitroParams encapsulates options to create a NitroClient
@@ -39,14 +40,15 @@ type NitroParams struct {
 //NitroClient has methods to configure the NetScaler
 //It abstracts the REST operations of the NITRO API
 type NitroClient struct {
-	url       string
-	statsURL  string
-	username  string
-	password  string
-	proxiedNs string
-	client    *http.Client
-	sessionid string
-	timeout   int
+	url          string
+	statsURL     string
+	username     string
+	password     string
+	proxiedNs    string
+	client       *http.Client
+	sessionidMux sync.RWMutex
+	sessionid    string
+	timeout      int
 }
 
 //NewNitroClient returns a usable NitroClient. Does not check validity of supplied parameters
@@ -59,6 +61,8 @@ func NewNitroClient(url string, username string, password string) *NitroClient {
 	c.username = username
 	c.password = password
 	c.client = &http.Client{}
+	c.sessionid = ""
+	c.timeout = 0
 	return c
 }
 
@@ -77,6 +81,7 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 	c.username = params.Username
 	c.password = params.Password
 	c.proxiedNs = params.ProxiedNs
+	c.sessionid = ""
 	c.timeout = params.Timeout
 	if params.SslVerify {
 		c.client = &http.Client{}

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -33,6 +33,7 @@ type NitroParams struct {
 	Password  string
 	ProxiedNs string
 	SslVerify bool
+	Timeout   int
 }
 
 //NitroClient has methods to configure the NetScaler
@@ -76,6 +77,7 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 	c.username = params.Username
 	c.password = params.Password
 	c.proxiedNs = params.ProxiedNs
+	c.timeout = params.Timeout
 	if params.SslVerify {
 		c.client = &http.Client{}
 	} else {
@@ -107,12 +109,22 @@ func NewNitroClientFromEnv() (*NitroClient, error) {
 			return nil, fmt.Errorf("Could not parse env variable NS_SSLVERIFY: valid values are true and false")
 		}
 	}
+	timeoutStr := os.Getenv("NS_TIMEOUT")
+	timeout := 0
+	if timeoutStr != "" {
+		var err error
+		timeout, err = strconv.Atoi(timeoutStr)
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse env variable NS_TIMEOUT: integer value is expected")
+		}
+	}
 	nitroParams := NitroParams{
 		Url:       url,
 		Username:  username,
 		Password:  password,
 		ProxiedNs: proxiedNs,
 		SslVerify: sslVerify,
+		Timeout:   timeout,
 	}
 	return NewNitroClientFromParams(nitroParams)
 }

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -60,7 +60,7 @@ func (c *NitroClient) getSessionid() string {
 
 // IsLoggedIn tells if user is already logged in
 func (c *NitroClient) IsLoggedIn() bool {
-	if len(c.sessionid) > 0 {
+	if len(c.getSessionid()) > 0 {
 		return true
 	}
 	return false

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -43,20 +43,22 @@ type logout struct {
 }
 
 // Login to netscaler and store the session
-func (c *NitroClient) Login() {
+func (c *NitroClient) Login() error {
 	loginObj := login{
 		Username: c.username,
 		Password: c.password,
 		Timeout:  c.timeout,
 	}
-	c.AddResource(Login.Type(), "login", loginObj)
+	_, err := c.AddResource(Login.Type(), "login", loginObj)
+	return err
 }
 
 // Logout from netscaler and clear the session
-func (c *NitroClient) Logout() {
+func (c *NitroClient) Logout() error {
 	logoutObj := logout{}
-	c.AddResource(Logout.Type(), "logout", logoutObj)
+	_, err := c.AddResource(Logout.Type(), "logout", logoutObj)
 	c.sessionid = ""
+	return err
 }
 
 //AddResource adds a resource of supplied type and name

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -73,7 +73,8 @@ func (c *NitroClient) AddResource(resourceType string, name string, resourceStru
 
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	if !strings.EqualFold(resourceType, "systemfile") {
+	var doNotPrintResources = []string{"systemfile", "login", "logout"}
+	if !contains(doNotPrintResources, resourceType) {
 		log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
 	}
 	body, err := c.createResource(resourceType, resourceJSON)

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 )
 
@@ -31,6 +32,37 @@ func JSONMarshal(t interface{}) ([]byte, error) {
 	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(t)
 	return buffer.Bytes(), err
+}
+
+type login struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Timeout  int    `json:"timeout,omitempty"`
+}
+
+type logout struct {
+}
+
+// Login to netscaler and store the session
+func (c *NitroClient) Login() {
+	loginObj := login{
+		Username: c.username,
+		Password: c.password,
+		Timeout:  c.timeout,
+	}
+	c.AddResource(GetStructName(loginObj), "login", loginObj)
+}
+
+// Logout from netscaler and clear the session
+func (c *NitroClient) Logout() {
+	logoutObj := logout{}
+	c.AddResource(GetStructName(logoutObj), "logout", logoutObj)
+	c.sessionid = ""
+}
+
+// GetStructName returns name of struct in lowercase for provided object
+func GetStructName(object interface{}) string {
+	return strings.ToLower(reflect.TypeOf(object).Name())
 }
 
 //AddResource adds a resource of supplied type and name

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 )
 
@@ -50,19 +49,14 @@ func (c *NitroClient) Login() {
 		Password: c.password,
 		Timeout:  c.timeout,
 	}
-	c.AddResource(GetStructName(loginObj), "login", loginObj)
+	c.AddResource(Login.Type(), "login", loginObj)
 }
 
 // Logout from netscaler and clear the session
 func (c *NitroClient) Logout() {
 	logoutObj := logout{}
-	c.AddResource(GetStructName(logoutObj), "logout", logoutObj)
+	c.AddResource(Logout.Type(), "logout", logoutObj)
 	c.sessionid = ""
-}
-
-// GetStructName returns name of struct in lowercase for provided object
-func GetStructName(object interface{}) string {
-	return strings.ToLower(reflect.TypeOf(object).Name())
 }
 
 //AddResource adds a resource of supplied type and name

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -42,10 +42,18 @@ type login struct {
 type logout struct {
 }
 
+// IsLoggedIn tells if user is already logged in
+func (c *NitroClient) IsLoggedIn() bool {
+	if len(c.sessionid) > 0 {
+		return true
+	}
+	return false
+}
+
 // Login to netscaler and store the session
 func (c *NitroClient) Login() error {
 	// Check if login is already done
-	if len(c.sessionid) > 0 {
+	if c.IsLoggedIn() {
 		return nil
 	}
 	loginObj := login{

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -44,6 +44,10 @@ type logout struct {
 
 // Login to netscaler and store the session
 func (c *NitroClient) Login() error {
+	// Check if login is already done
+	if len(c.sessionid) > 0 {
+		return nil
+	}
 	loginObj := login{
 		Username: c.username,
 		Password: c.password,

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -815,7 +815,7 @@ func TestTokenBasedAuth(t *testing.T) {
 	time.Sleep(15 * time.Second)
 	_, err = client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
-		if len(client.sessionid) > 0 {
+		if client.IsLoggedIn() {
 			t.Error("Sessionid not cleared")
 			return
 		}

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -769,7 +769,12 @@ func TestDesiredStateServicegroupAPI(t *testing.T) {
 
 // TestTokenBasedAuth tests token-based authentication and tests if session-is is cleared in case of session-expiry
 func TestTokenBasedAuth(t *testing.T) {
-	client.Login()
+	var err error
+	err = client.Login()
+	if err != nil {
+		t.Error("Login Failed")
+		return
+	}
 	rndIP := randomIP()
 	lbName := "test_lb_" + randomString(5)
 	lb1 := lb.Lbvserver{
@@ -779,7 +784,7 @@ func TestTokenBasedAuth(t *testing.T) {
 		Servicetype: "HTTP",
 		Port:        8000,
 	}
-	_, err := client.AddResource(Lbvserver.Type(), lbName, &lb1)
+	_, err = client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not add Lbvserver: ", err)
 		log.Println("Not continuing test")
@@ -798,7 +803,11 @@ func TestTokenBasedAuth(t *testing.T) {
 		log.Println("Cannot continue")
 		return
 	}
-	client.Logout()
+	err = client.Logout()
+	if err != nil {
+		t.Error("Logout Failed")
+		return
+	}
 
 	// Test if session-id is cleared in case of session-expiry
 	client.timeout = 10
@@ -814,6 +823,4 @@ func TestTokenBasedAuth(t *testing.T) {
 	} else {
 		t.Error("Adding lbvserver should have failed because of session-expiry")
 	}
-	log.Println("session-id after:", client.sessionid)
-	client.Logout()
 }

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -24,10 +24,10 @@ import (
 
 	"os"
 
-	"github.com/imkritesh/go-nitro/config/basic"
-	"github.com/imkritesh/go-nitro/config/lb"
-	"github.com/imkritesh/go-nitro/config/network"
-	"github.com/imkritesh/go-nitro/config/ns"
+	"github.com/chiradeep/go-nitro/config/basic"
+	"github.com/chiradeep/go-nitro/config/lb"
+	"github.com/chiradeep/go-nitro/config/network"
+	"github.com/chiradeep/go-nitro/config/ns"
 )
 
 var client *NitroClient

--- a/netscaler/netscaler_resource.go
+++ b/netscaler/netscaler_resource.go
@@ -126,7 +126,6 @@ func (c *NitroClient) createHTTPRequest(method string, url string, buff *bytes.B
 	resourceName := splitStrings[len(splitStrings)-1]
 	if c.proxiedNs == "" {
 		if len(c.sessionid) > 0 {
-			log.Println("[DEBUG] createHTTPRequest: Using token-based authentication")
 			req.Header.Set("Set-Cookie", "NITRO_AUTH_TOKEN="+c.sessionid)
 		} else {
 			if resourceName != "login" {
@@ -136,7 +135,6 @@ func (c *NitroClient) createHTTPRequest(method string, url string, buff *bytes.B
 		}
 	} else {
 		if len(c.sessionid) > 0 {
-			log.Println("[DEBUG] createHTTPRequest: Using token-based authentication")
 			req.Header.Set("Set-Cookie", "NITRO_AUTH_TOKEN="+c.sessionid)
 		} else {
 			if resourceName != "login" {

--- a/netscaler/netscaler_resource.go
+++ b/netscaler/netscaler_resource.go
@@ -31,9 +31,14 @@ import (
 // Idempotent flag can't be added for these resources
 var idempotentInvalidResources = []string{"login", "logout", "reboot", "shutdown", "ping", "ping6", "traceroute", "traceroute6", "install"}
 
+const (
+	nsErrSessionExpired = 444
+	nsErrAuthTimeout    = 1027
+)
+
 func contains(slice []string, val string) bool {
 	for _, item := range slice {
-		if item == val {
+		if strings.EqualFold(item, val) {
 			return true
 		}
 	}
@@ -170,7 +175,7 @@ func (c *NitroClient) doHTTPRequest(method string, urlstr string, bytes *bytes.B
 		err2 := json.Unmarshal(body, &data)
 		if err2 == nil {
 			data["errorcode"] = int(data["errorcode"].(float64))
-			if data["errorcode"] == 444 || data["errorcode"] == 1027 {
+			if data["errorcode"] == nsErrSessionExpired || data["errorcode"] == nsErrAuthTimeout {
 				c.sessionid = ""
 			}
 		}

--- a/netscaler/netscaler_resource.go
+++ b/netscaler/netscaler_resource.go
@@ -131,7 +131,7 @@ func (c *NitroClient) createHTTPRequest(method string, urlstr string, buff *byte
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	if c.proxiedNs == "" {
-		if len(c.sessionid) > 0 {
+		if c.IsLoggedIn() {
 			req.Header.Set("Set-Cookie", "NITRO_AUTH_TOKEN="+c.getSessionid())
 		} else {
 			if resourceType != "login" {

--- a/netscaler/resources.go
+++ b/netscaler/resources.go
@@ -604,6 +604,8 @@ const (
 	Linkset_binding
 	Linkset_channel_binding
 	Linkset_interface_binding
+	Login
+	Logout
 	Nat64
 	Nd6
 	Nd6ravariables
@@ -1635,6 +1637,8 @@ var resources = []string{
 	"linkset_binding",
 	"linkset_channel_binding",
 	"linkset_interface_binding",
+	"login",
+	"logout",
 	"nat64",
 	"nd6",
 	"nd6ravariables",


### PR DESCRIPTION
This PR enhances the go-nitro package with Token-based (or session-based) authentication mechanism. 
Login() and Logout() NITRO API methods are introduced. Before doing any nitro call, if the user performs Login(), then session-id is stored in the NitroClient. This sessionid (NITRO_AUTH_TOKEN) is used for subsequent Nitro calls in Set-cookie header. It alleviates the need of passing username/password in each and every Nitro call. 
If the user doesn't perform Login() operation, then basic-auth mechanism will work where username/password will be passed in every request.

Unit test `TestTokenBasedAuth` is added in config_test.go.