### PR TITLE
Use hclog instead of log.printf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SDK_ONLY_PKGS=$(shell go list ./... | grep -v "/vendor/" | grep -v "/example")
-SDK_TEST_ONLY_PKGS=$(shell go list ./... | grep -v "/vendor/" | grep -v "/config" | grep -v "/example")
+SDK_TEST_ONLY_PKGS=$(shell go list ./... | grep -v "/vendor/" | grep -v "/config" | grep -v "/example" | grep -v "/stats")
 
 all: build unit
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/chiradeep/go-nitro
 
 go 1.16
+
+require github.com/hashicorp/go-hclog v0.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/hashicorp/go-hclog v0.16.1 h1:IVQwpTGNRRIHafnTs2dQLIk4ENtneRIEEJWOVDqz99o=
+github.com/hashicorp/go-hclog v0.16.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -119,10 +120,20 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 		}
 		c.client = &http.Client{Transport: tr}
 	}
+	logLevel, ok := os.LookupEnv("NITRO_LOG")
+	level := hclog.LevelFromString("OFF")
+	if ok {
+		lvl := hclog.LevelFromString(logLevel)
+		if lvl != hclog.NoLevel {
+			level = lvl
+		} else {
+			log.Printf("go-nitro: NITRO_LOG not set to a valid log level (%s), defaulting to OFF", logLevel)
+		}
+	}
 	//c.logger = hclog.Default()
 	c.logger = hclog.New(&hclog.LoggerOptions{
 		Name:            "go-nitro",
-		Level:           hclog.LevelFromString("OFF"),
+		Level:           level,
 		Color:           hclog.AutoColor,
 		IncludeLocation: true,
 	})

--- a/netscaler/client.go
+++ b/netscaler/client.go
@@ -121,8 +121,10 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 	}
 	//c.logger = hclog.Default()
 	c.logger = hclog.New(&hclog.LoggerOptions{
-		Name:  "go-nitro",
-		Level: hclog.LevelFromString("TRACE"),
+		Name:            "go-nitro",
+		Level:           hclog.LevelFromString("OFF"),
+		Color:           hclog.AutoColor,
+		IncludeLocation: true,
 	})
 	return c, nil
 }

--- a/netscaler/client_test.go
+++ b/netscaler/client_test.go
@@ -17,8 +17,8 @@ package netscaler
 
 import (
 	"os"
-	"testing"
 	"strings"
+	"testing"
 )
 
 func TestClientCreate(t *testing.T) {

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -619,7 +619,7 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 	var data map[string]interface{}
 	result, err := c.listResource(resourceType, "")
 	if err != nil {
-		c.logger.Info(" FindAllResources: No objects found", "resourceType", resourceType)
+		c.logger.Trace(" FindAllResources: No objects found", "resourceType", resourceType)
 		return make([]map[string]interface{}, 0, 0), nil
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
@@ -628,7 +628,7 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 	}
 	rsrcs, ok := data[resourceType]
 	if !ok || rsrcs == nil {
-		c.logger.Info(" FindAllResources: resource not found", "resourceType", resourceType)
+		c.logger.Trace(" FindAllResources: resource not found", "resourceType", resourceType)
 		return make([]map[string]interface{}, 0, 0), nil
 	}
 	resources := data[resourceType].([]interface{})
@@ -645,7 +645,7 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) bool {
 	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
 	if err != nil {
-		c.logger.Info("ResourceBindingExists: No bound resource to found", "resourceType", resourceType, "name", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
+		c.logger.Trace("ResourceBindingExists: No bound resource to found", "resourceType", resourceType, "name", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 		return false
 	}
 
@@ -660,7 +660,7 @@ func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName st
 		return false
 	}
 
-	c.logger.Info("ResourceBindingExists: of type   is bound to  type and name ", "resourceType", resourceType, "resourceName", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
+	c.logger.Trace("ResourceBindingExists: of type   is bound to  type and name ", "resourceType", resourceType, "resourceName", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 	return true
 }
 

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -266,7 +266,7 @@ func (c *NitroClient) UpdateResource(resourceType string, name string, resourceS
 		nsResource[resourceType] = resourceStruct
 		resourceJSON, err := JSONMarshal(nsResource)
 
-		c.logger.Debug("UpdateResource: Resourcejson is " + string(resourceJSON))
+		c.logger.Debug("UpdateResource", "resourceJSON", string(resourceJSON))
 
 		body, err := c.updateResource(resourceType, name, resourceJSON)
 		if err != nil {
@@ -285,7 +285,7 @@ func (c *NitroClient) UpdateUnnamedResource(resourceType string, resourceStruct 
 	nsResource[resourceType] = resourceStruct
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	c.logger.Debug("UpdateResource: Resourcejson is " + string(resourceJSON))
+	c.logger.Trace("UpdateResource", "resourcejson", string(resourceJSON))
 
 	body, err := c.updateUnnamedResource(resourceType, resourceJSON)
 	if err != nil {
@@ -304,7 +304,7 @@ func (c *NitroClient) ChangeResource(resourceType string, name string, resourceS
 		nsResource[resourceType] = resourceStruct
 		resourceJSON, err := json.Marshal(nsResource)
 
-		c.logger.Debug("ChangeResource: Resourcejson is " + string(resourceJSON))
+		c.logger.Trace("ChangeResource:", "resourcejson", string(resourceJSON))
 
 		body, err := c.changeResource(resourceType, name, resourceJSON)
 		if err != nil {
@@ -321,14 +321,14 @@ func (c *NitroClient) DeleteResource(resourceType string, resourceName string) e
 
 	_, err := c.listResource(resourceType, resourceName)
 	if err == nil { // resource exists
-		c.logger.Debug("DeleteResource Found resource of type %s: %s", resourceType, resourceName)
+		c.logger.Trace("DeleteResource Found resource ", "resourceType", resourceType, "resourceName", resourceName)
 		_, err = c.deleteResource(resourceType, resourceName)
 		if err != nil {
-			c.logger.Debug("[ERROR] go-nitro: Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
+			c.logger.Warn("Failed to delete resource", "resourceType", resourceType, "resourceName", resourceName, "error", err)
 			return err
 		}
 	} else {
-		c.logger.Info(" DeleteResource: Resource %s already deleted ", resourceName)
+		c.logger.Info("DeleteResource: Resource already deleted ", "resourceType", resourceType, "resourceName", resourceName)
 	}
 	return nil
 }
@@ -339,14 +339,14 @@ func (c *NitroClient) DeleteResourceWithArgs(resourceType string, resourceName s
 
 	_, err := c.listResourceWithArgs(resourceType, resourceName, args)
 	if err == nil { // resource exists
-		c.logger.Info(" DeleteResource found resource of type %s: %s", resourceType, resourceName)
+		c.logger.Trace("DeleteResource Found resource ", "resourceType", resourceType, "resourceName", resourceName)
 		_, err = c.deleteResourceWithArgs(resourceType, resourceName, args)
 		if err != nil {
-			c.logger.Error("Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
+			c.logger.Warn("Failed to delete resource", "resourceType", resourceType, "resourceName", resourceName, "error", err)
 			return err
 		}
 	} else {
-		c.logger.Info(" Resource %s already deleted ", resourceName)
+		c.logger.Info("DeleteResource: Resource already deleted ", "resourceType", resourceType, "resourceName", resourceName)
 	}
 	return nil
 }
@@ -356,14 +356,16 @@ func (c *NitroClient) DeleteResourceWithArgsMap(resourceType string, resourceNam
 
 	_, err := c.listResourceWithArgsMap(resourceType, resourceName, args)
 	if err == nil { // resource exists
-		c.logger.Info(" DeleteResource found resource of type %s: %s", resourceType, resourceName)
+		c.logger.Trace("DeleteResource Found resource ", "resourceType", resourceType, "resourceName", resourceName)
+
 		_, err = c.deleteResourceWithArgsMap(resourceType, resourceName, args)
 		if err != nil {
-			c.logger.Error("Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
+			c.logger.Warn("Failed to delete resource", "resourceType", resourceType, "resourceName", resourceName, "error", err)
+
 			return err
 		}
 	} else {
-		c.logger.Info(" Resource %s already deleted ", resourceName)
+		c.logger.Info(" Resource already deleted ", "resourceType", resourceType, "resourceName", resourceName)
 	}
 	return nil
 }
@@ -395,12 +397,12 @@ func (c *NitroClient) BindResource(bindToResourceType string, bindToResourceName
 func (c *NitroClient) UnbindResource(boundToResourceType string, boundToResourceName string, boundResourceType string, boundResourceName string, bindingFilterName string) error {
 
 	if !c.ResourceExists(boundToResourceType, boundToResourceName) {
-		c.logger.Info(" Unbind: BoundTo Resource  does not exist", boundToResourceType, boundToResourceName)
+		c.logger.Info(" Unbind: BoundTo Resource  does not exist", "boundToResourceType", boundToResourceType, "boundToResourceName", boundToResourceName)
 		return nil
 	}
 
 	if !c.ResourceExists(boundResourceType, boundResourceName) {
-		c.logger.Info(" Unbind: Bound Resource  does not exist", boundResourceType, boundResourceName)
+		c.logger.Info(" Unbind: Bound Resource  does not exist", "boundResourceType", boundResourceType, "boundResourceName", boundResourceName)
 		return nil
 	}
 
@@ -416,10 +418,10 @@ func (c *NitroClient) UnbindResource(boundToResourceType string, boundToResource
 func (c *NitroClient) ResourceExists(resourceType string, resourceName string) bool {
 	_, err := c.listResource(resourceType, resourceName)
 	if err != nil {
-		c.logger.Info(" No resource found", "resourceType", resourceType, "resourceName", resourceName)
+		c.logger.Debug("ResourceExists: No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return false
 	}
-	c.logger.Info(" resource is already present", resourceType, resourceName)
+	c.logger.Debug("ResourceExists: resource is already present", "resourceType", resourceType, "resourceName", resourceName)
 	return true
 }
 
@@ -428,16 +430,16 @@ func (c *NitroClient) FindResourceArray(resourceType string, resourceName string
 	var data map[string]interface{}
 	result, err := c.listResource(resourceType, resourceName)
 	if err != nil {
-		c.logger.Warn("FindResourceArray: No resources found", resourceType, resourceName)
+		c.logger.Warn("FindResourceArray: No resources found", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResourceArray: No resource %s of type %s found", resourceName, resourceType)
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
-		c.logger.Error("FindResourceArray: Failed to unmarshal Netscaler Response!", resourceType, resourceName)
+		c.logger.Error("FindResourceArray: Failed to unmarshal Netscaler Response!", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindResourceArray: Failed to unmarshal Netscaler Response:resource %s of type %s", resourceName, resourceType)
 	}
 	rsrcs, ok := data[resourceType]
 	if !ok || rsrcs == nil {
-		c.logger.Warn("FindResourceArray No resource found", resourceType, resourceName)
+		c.logger.Warn("FindResourceArray No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResourceArray: No resource %s of type %s found", resourceName, resourceType)
 	}
 	resources := data[resourceType].([]interface{})
@@ -478,7 +480,7 @@ func (c *NitroClient) FindResource(resourceType string, resourceName string) (ma
 	var data map[string]interface{}
 	result, err := c.listResource(resourceType, resourceName)
 	if err != nil {
-		c.logger.Warn("FindResource: No %s %s found", resourceType, resourceName)
+		c.logger.Warn("FindResource: No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResource: No resource %s of type %s found", resourceName, resourceType)
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
@@ -487,7 +489,7 @@ func (c *NitroClient) FindResource(resourceType string, resourceName string) (ma
 	}
 	rsrc, ok := data[resourceType]
 	if !ok || rsrc == nil {
-		c.logger.Warn("FindResource No resource found", resourceType, resourceName)
+		c.logger.Warn("FindResource No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResource: No resource %s of type %s found", resourceName, resourceType)
 	}
 
@@ -672,7 +674,7 @@ func (c *NitroClient) FindBoundResource(resourceType string, resourceName string
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(result, &data); err != nil {
-		c.logger.Error("FindBoundResource: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindBoundResource: Failed to unmarshal Netscaler Response!", "error", err)
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindBoundResource: Failed to unmarshal Netscaler Response!, err=%s", err)
 	}
 	bindingType := fmt.Sprintf("%s_%s_binding", resourceType, boundResourceType)
@@ -690,13 +692,13 @@ func (c *NitroClient) FindBoundResource(resourceType string, resourceName string
 func (c *NitroClient) FindAllBoundResources(resourceType string, resourceName string, boundResourceType string) ([]map[string]interface{}, error) {
 	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, "", "")
 	if err != nil {
-		c.logger.Info(" FindAllBoundResources: No %s %s to %s  binding found", resourceType, resourceName, boundResourceType)
+		c.logger.Info("FindAllBoundResources: No binding found", "resourceType", resourceType, "resourceName", "resourceName", resourceName, "boundResourceType", boundResourceType)
 		return nil, fmt.Errorf("[ERROR] go-nitro: No %s %s to %s binding found, err=%s", resourceType, resourceName, boundResourceType, err)
 	}
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(result, &data); err != nil {
-		c.logger.Error("FindAllBoundResources: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindAllBoundResources: Failed to unmarshal Netscaler Response!", "error", err)
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindAllBoundResources: Failed to unmarshal Netscaler Response!, err=%s", err)
 	}
 	bindingType := fmt.Sprintf("%s_%s_binding", resourceType, boundResourceType)
@@ -730,7 +732,7 @@ func (c *NitroClient) EnableFeatures(featureNames []string) error {
 
 	featureJSON, err := JSONMarshal(featureStruct)
 	if err != nil {
-		c.logger.Error("EnableFeatures: Failed to marshal features to JSON")
+		c.logger.Error("EnableFeatures: Failed to marshal features to JSON", "error", err)
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal features to JSON")
 	}
 
@@ -756,7 +758,7 @@ func (c *NitroClient) DisableFeatures(featureNames []string) error {
 
 	featureJSON, err := JSONMarshal(featureStruct)
 	if err != nil {
-		c.logger.Error("DisableFeatures: Failed to marshal features to JSON")
+		c.logger.Error("DisableFeatures: Failed to marshal features to JSON", "error", err)
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal features to JSON")
 	}
 
@@ -776,12 +778,12 @@ func (c *NitroClient) ListEnabledFeatures() ([]string, error) {
 	}
 	var data map[string]interface{}
 	if err = json.Unmarshal(bytes, &data); err != nil {
-		c.logger.Error("FindAllBoundResources: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("ListEnabledFeatures: Failed to unmarshal Netscaler Response!", "error", err)
 		return []string{}, fmt.Errorf("[ERROR] go-nitro: Failed to unmarshal Netscaler Response to list Features")
 	}
 	feat, ok := data["nsfeature"]
 	if !ok || feat == nil {
-		c.logger.Error("No features found")
+		c.logger.Error("ListEnabledFeatures: No features found")
 		return []string{}, fmt.Errorf("[ERROR] go-nitro: No features found")
 	}
 
@@ -815,7 +817,7 @@ func (c *NitroClient) EnableModes(modeNames []string) error {
 
 	modeJSON, err := JSONMarshal(modeStruct)
 	if err != nil {
-		c.logger.Error("EnableModes: Failed to marshal modes to JSON")
+		c.logger.Error("EnableModes: Failed to marshal modes to JSON", "error", err)
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal modes to JSON")
 	}
 
@@ -835,12 +837,12 @@ func (c *NitroClient) ListEnabledModes() ([]string, error) {
 	}
 	var data map[string]interface{}
 	if err = json.Unmarshal(bytes, &data); err != nil {
-		c.logger.Error("ListEnabledModes: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("ListEnabledModes: Failed to unmarshal Netscaler Response!", "error", err)
 		return []string{}, fmt.Errorf("[ERROR] go-nitro: Failed to unmarshal Netscaler Response to list Modes")
 	}
 	mode, ok := data["nsmode"]
 	if !ok || mode == nil {
-		c.logger.Error("No modes found")
+		c.logger.Error("ListEnabledModes: No modes found")
 		return []string{}, fmt.Errorf("[ERROR] No modes found")
 	}
 
@@ -870,10 +872,10 @@ func (c *NitroClient) SaveConfig() error {
 
 	saveJSON, err := JSONMarshal(saveStruct)
 	if err != nil {
-		c.logger.Error("SaveConfig: Failed to marshal save config to JSON")
+		c.logger.Error("SaveConfig: Failed to marshal save config to JSON", "error", err)
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal save config to JSON")
 	}
-	c.logger.Debug("saveJSON is " + string(saveJSON))
+	c.logger.Debug("saveJSON", "json", string(saveJSON))
 
 	err = c.saveConfig(saveJSON)
 	if err != nil {
@@ -896,7 +898,7 @@ func (c *NitroClient) ClearConfig() error {
 
 	clearJSON, err := JSONMarshal(clearStruct)
 	if err != nil {
-		c.logger.Error("ClearConfig: Failed to marshal clear config to JSON")
+		c.logger.Error("ClearConfig: Failed to marshal clear config to JSON", "error", err)
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal clear config to JSON")
 	}
 	c.logger.Trace("clearJSON is ", "text", string(clearJSON))

--- a/netscaler/config.go
+++ b/netscaler/config.go
@@ -23,6 +23,8 @@ import (
 	"log"
 	"sort"
 	"strings"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 // https://stackoverflow.com/questions/28595664/how-to-stop-json-marshal-from-escaping-and/28596225#28596225
@@ -50,6 +52,10 @@ type login struct {
 }
 
 type logout struct {
+}
+
+func (c *NitroClient) SetLogLevel(level string) {
+	c.logger.SetLevel(hclog.LevelFromString(level))
 }
 
 func (c *NitroClient) updateSessionid(sessionid string) {
@@ -92,11 +98,11 @@ func constructQueryMapString(prefix string, queryMap map[string]string) string {
 	// Make it deterministic for testing's sake
 	sort.Strings(keys)
 	lastIndex := len(keys) - 1
-	log.Printf("[DEBUG] lastindex %v", lastIndex)
+	//c.logger.Printf("lastindex %v", lastIndex)
 
 	for i, k := range keys {
 		v := queryMap[k]
-		log.Printf("i %v", i)
+		//c.logger.Printf("i %v", i)
 		if i < lastIndex {
 			queryBuilder.WriteString(fmt.Sprintf("%s:%s,", k, v))
 		} else {
@@ -185,7 +191,7 @@ func (c *NitroClient) AddResourceReturnBody(resourceType string, name string, re
 
 	var doNotPrintResources = []string{"systemfile", "login", "logout"}
 	if !contains(doNotPrintResources, resourceType) {
-		log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
+		c.logger.Trace("AddResourceReturnBody", "resourceJSON", string(resourceJSON))
 	}
 	body, err := c.createResource(resourceType, resourceJSON)
 	if err != nil {
@@ -204,7 +210,7 @@ func (c *NitroClient) AddResource(resourceType string, name string, resourceStru
 
 	var doNotPrintResources = []string{"systemfile", "login", "logout"}
 	if !contains(doNotPrintResources, resourceType) {
-		log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
+		c.logger.Trace("AddResource", "resourceJSON", string(resourceJSON))
 	}
 	body, err := c.createResource(resourceType, resourceJSON)
 	if err != nil {
@@ -223,7 +229,7 @@ func (c *NitroClient) ApplyResource(resourceType string, resourceStruct interfac
 
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
+	c.logger.Trace("ApplyResource ", "resourceJSON", string(resourceJSON))
 
 	body, err := c.applyResource(resourceType, resourceJSON)
 	if err != nil {
@@ -242,7 +248,7 @@ func (c *NitroClient) ActOnResource(resourceType string, resourceStruct interfac
 
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	log.Printf("[TRACE] go-nitro: Resourcejson is " + string(resourceJSON))
+	c.logger.Trace("Resourcejson is ", "resourceJSON", string(resourceJSON))
 
 	_, err = c.actOnResource(resourceType, resourceJSON, action)
 	if err != nil {
@@ -260,7 +266,7 @@ func (c *NitroClient) UpdateResource(resourceType string, name string, resourceS
 		nsResource[resourceType] = resourceStruct
 		resourceJSON, err := JSONMarshal(nsResource)
 
-		log.Printf("[DEBUG] go-nitro: UpdateResource: Resourcejson is " + string(resourceJSON))
+		c.logger.Debug("UpdateResource: Resourcejson is " + string(resourceJSON))
 
 		body, err := c.updateResource(resourceType, name, resourceJSON)
 		if err != nil {
@@ -279,7 +285,7 @@ func (c *NitroClient) UpdateUnnamedResource(resourceType string, resourceStruct 
 	nsResource[resourceType] = resourceStruct
 	resourceJSON, err := JSONMarshal(nsResource)
 
-	log.Printf("[DEBUG] go-nitro: UpdateResource: Resourcejson is " + string(resourceJSON))
+	c.logger.Debug("UpdateResource: Resourcejson is " + string(resourceJSON))
 
 	body, err := c.updateUnnamedResource(resourceType, resourceJSON)
 	if err != nil {
@@ -298,7 +304,7 @@ func (c *NitroClient) ChangeResource(resourceType string, name string, resourceS
 		nsResource[resourceType] = resourceStruct
 		resourceJSON, err := json.Marshal(nsResource)
 
-		log.Printf("[DEBUG] go-nitro: ChangeResource: Resourcejson is " + string(resourceJSON))
+		c.logger.Debug("ChangeResource: Resourcejson is " + string(resourceJSON))
 
 		body, err := c.changeResource(resourceType, name, resourceJSON)
 		if err != nil {
@@ -315,14 +321,14 @@ func (c *NitroClient) DeleteResource(resourceType string, resourceName string) e
 
 	_, err := c.listResource(resourceType, resourceName)
 	if err == nil { // resource exists
-		log.Printf("[DEBUG] go-nitro: DeleteResource Found resource of type %s: %s", resourceType, resourceName)
+		c.logger.Debug("DeleteResource Found resource of type %s: %s", resourceType, resourceName)
 		_, err = c.deleteResource(resourceType, resourceName)
 		if err != nil {
-			log.Printf("[ERROR] go-nitro: Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
+			c.logger.Debug("[ERROR] go-nitro: Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
 			return err
 		}
 	} else {
-		log.Printf("[INFO] go-nitro: DeleteResource: Resource %s already deleted ", resourceName)
+		c.logger.Info(" DeleteResource: Resource %s already deleted ", resourceName)
 	}
 	return nil
 }
@@ -333,14 +339,14 @@ func (c *NitroClient) DeleteResourceWithArgs(resourceType string, resourceName s
 
 	_, err := c.listResourceWithArgs(resourceType, resourceName, args)
 	if err == nil { // resource exists
-		log.Printf("[INFO] go-nitro: DeleteResource found resource of type %s: %s", resourceType, resourceName)
+		c.logger.Info(" DeleteResource found resource of type %s: %s", resourceType, resourceName)
 		_, err = c.deleteResourceWithArgs(resourceType, resourceName, args)
 		if err != nil {
-			log.Printf("[ERROR] go-nitro: Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
+			c.logger.Error("Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
 			return err
 		}
 	} else {
-		log.Printf("[INFO] go-nitro: Resource %s already deleted ", resourceName)
+		c.logger.Info(" Resource %s already deleted ", resourceName)
 	}
 	return nil
 }
@@ -350,32 +356,32 @@ func (c *NitroClient) DeleteResourceWithArgsMap(resourceType string, resourceNam
 
 	_, err := c.listResourceWithArgsMap(resourceType, resourceName, args)
 	if err == nil { // resource exists
-		log.Printf("[INFO] go-nitro: DeleteResource found resource of type %s: %s", resourceType, resourceName)
+		c.logger.Info(" DeleteResource found resource of type %s: %s", resourceType, resourceName)
 		_, err = c.deleteResourceWithArgsMap(resourceType, resourceName, args)
 		if err != nil {
-			log.Printf("[ERROR] go-nitro: Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
+			c.logger.Error("Failed to delete resourceType %s: %s, err=%s", resourceType, resourceName, err)
 			return err
 		}
 	} else {
-		log.Printf("[INFO] go-nitro: Resource %s already deleted ", resourceName)
+		c.logger.Info(" Resource %s already deleted ", resourceName)
 	}
 	return nil
 }
 
 //BindResource binds the 'bindingResourceName' to the 'bindToResourceName'.
 func (c *NitroClient) BindResource(bindToResourceType string, bindToResourceName string, bindingResourceType string, bindingResourceName string, bindingStruct interface{}) error {
-	if c.ResourceExists(bindToResourceType, bindToResourceName) == false {
+	if !c.ResourceExists(bindToResourceType, bindToResourceName) {
 		return fmt.Errorf("[ERROR] go-nitro: BindTo Resource %s of type %s does not exist", bindToResourceType, bindToResourceName)
 	}
 
-	if c.ResourceExists(bindingResourceType, bindingResourceName) == false {
+	if !c.ResourceExists(bindingResourceType, bindingResourceName) {
 		return fmt.Errorf("[ERROR] go-nitro: Binding Resource %s of type %s does not exist", bindingResourceType, bindingResourceName)
 	}
 	bindingName := bindToResourceType + "_" + bindingResourceType + "_binding"
 	nsBinding := make(map[string]interface{})
 	nsBinding[bindingName] = bindingStruct
 
-	resourceJSON, err := JSONMarshal(nsBinding)
+	resourceJSON, _ := JSONMarshal(nsBinding)
 
 	body, err := c.createResource(bindingName, resourceJSON)
 	if err != nil {
@@ -388,19 +394,19 @@ func (c *NitroClient) BindResource(bindToResourceType string, bindToResourceName
 //UnbindResource unbinds 'boundResourceName' from 'boundToResource'
 func (c *NitroClient) UnbindResource(boundToResourceType string, boundToResourceName string, boundResourceType string, boundResourceName string, bindingFilterName string) error {
 
-	if c.ResourceExists(boundToResourceType, boundToResourceName) == false {
-		log.Printf("[INFO] go-nitro: Unbind: BoundTo Resource %s of type %s does not exist", boundToResourceType, boundToResourceName)
+	if !c.ResourceExists(boundToResourceType, boundToResourceName) {
+		c.logger.Info(" Unbind: BoundTo Resource  does not exist", boundToResourceType, boundToResourceName)
 		return nil
 	}
 
-	if c.ResourceExists(boundResourceType, boundResourceName) == false {
-		log.Printf("[INFO] go-nitro: Unbind: Bound Resource %s of type %s does not exist", boundResourceType, boundResourceName)
+	if !c.ResourceExists(boundResourceType, boundResourceName) {
+		c.logger.Info(" Unbind: Bound Resource  does not exist", boundResourceType, boundResourceName)
 		return nil
 	}
 
 	_, err := c.unbindResource(boundToResourceType, boundToResourceName, boundResourceType, boundResourceName, bindingFilterName)
 	if err != nil {
-		return fmt.Errorf("[ERROR] go-nitro: Failed to unbind  %s:%s from %s:%s, err=%s", boundResourceType, boundResourceName, boundToResourceType, boundToResourceName, err)
+		return fmt.Errorf("[ERROR] Failed to unbind  %s:%s from %s:%s, err=%s", boundResourceType, boundResourceName, boundToResourceType, boundToResourceName, err)
 	}
 
 	return nil
@@ -410,10 +416,10 @@ func (c *NitroClient) UnbindResource(boundToResourceType string, boundToResource
 func (c *NitroClient) ResourceExists(resourceType string, resourceName string) bool {
 	_, err := c.listResource(resourceType, resourceName)
 	if err != nil {
-		log.Printf("[INFO] go-nitro: No %s %s found", resourceType, resourceName)
+		c.logger.Info(" No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return false
 	}
-	log.Printf("[INFO] go-nitro: %s %s is already present", resourceType, resourceName)
+	c.logger.Info(" resource is already present", resourceType, resourceName)
 	return true
 }
 
@@ -422,16 +428,16 @@ func (c *NitroClient) FindResourceArray(resourceType string, resourceName string
 	var data map[string]interface{}
 	result, err := c.listResource(resourceType, resourceName)
 	if err != nil {
-		log.Printf("[WARN] go-nitro: FindResourceArray: No %s %s found", resourceType, resourceName)
+		c.logger.Warn("FindResourceArray: No resources found", resourceType, resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResourceArray: No resource %s of type %s found", resourceName, resourceType)
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: FindResourceArray: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindResourceArray: Failed to unmarshal Netscaler Response!", resourceType, resourceName)
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindResourceArray: Failed to unmarshal Netscaler Response:resource %s of type %s", resourceName, resourceType)
 	}
 	rsrcs, ok := data[resourceType]
 	if !ok || rsrcs == nil {
-		log.Printf("[WARN] go-nitro: FindResourceArray No %s type with name %s found", resourceType, resourceName)
+		c.logger.Warn("FindResourceArray No resource found", resourceType, resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResourceArray: No resource %s of type %s found", resourceName, resourceType)
 	}
 	resources := data[resourceType].([]interface{})
@@ -447,16 +453,16 @@ func (c *NitroClient) FindFilteredResourceArray(resourceType string, filter map[
 	var data map[string]interface{}
 	result, err := c.listFilteredResource(resourceType, filter)
 	if err != nil {
-		log.Printf("[WARN] go-nitro: FindFilteredResourceArray: No %s found matching filter %s", resourceType, filter)
+		c.logger.Warn("FindFilteredResourceArray: No resource found matching filter", "resourceType", resourceType, "filter", filter)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindFilteredResourceArray: No resource of type %s found matching filter %s", resourceType, filter)
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
-		log.Println("[ERROR] go-nitro: FindFilteredResourceArray: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindFilteredResourceArray: Failed to unmarshal Netscaler Response!")
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindFilteredResourceArray: Failed to unmarshal Netscaler Response:resource of type %s matching filter %s", resourceType, filter)
 	}
 	rsrcs, ok := data[resourceType]
 	if !ok || rsrcs == nil {
-		log.Printf("[WARN] go-nitro: FindFilteredResourceArray No %s type matching filter %s found", resourceType, filter)
+		c.logger.Warn("FindFilteredResourceArray No resource matching filter found", "resourceType", resourceType, "filter", filter)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindFilteredResourceArray: No resource type %s matching filter %s found", filter, resourceType)
 	}
 	resources := data[resourceType].([]interface{})
@@ -472,16 +478,16 @@ func (c *NitroClient) FindResource(resourceType string, resourceName string) (ma
 	var data map[string]interface{}
 	result, err := c.listResource(resourceType, resourceName)
 	if err != nil {
-		log.Printf("[WARN] go-nitro: FindResource: No %s %s found", resourceType, resourceName)
+		c.logger.Warn("FindResource: No %s %s found", resourceType, resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResource: No resource %s of type %s found", resourceName, resourceType)
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: FindResource: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindResource: Failed to unmarshal Netscaler Response!")
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindResource: Failed to unmarshal Netscaler Response:resource %s of type %s", resourceName, resourceType)
 	}
 	rsrc, ok := data[resourceType]
 	if !ok || rsrc == nil {
-		log.Printf("[WARN] go-nitro: FindResource No %s type with name %s found", resourceType, resourceName)
+		c.logger.Warn("FindResource No resource found", resourceType, resourceName)
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResource: No resource %s of type %s found", resourceName, resourceType)
 	}
 
@@ -491,7 +497,7 @@ func (c *NitroClient) FindResource(resourceType string, resourceName string) (ma
 	case []interface{}:
 		return result[0].(map[string]interface{}), nil
 	default:
-		log.Printf("[WARN] go-nitro: FindResource Unable to determine type of response")
+		c.logger.Warn("FindResource Unable to determine type of response")
 		return nil, fmt.Errorf("[INFO] go-nitro: FindResource: Unable to determine type of response")
 	}
 }
@@ -522,10 +528,9 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 
 	url := urlBuilder.String()
 
-	log.Printf("[TRACE] go-nitro: FindResourceArrayWithParams: url is %s", url)
+	c.logger.Trace("FindResourceArrayWithParams: url is", "url", url)
 	result, httpErr := c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
-	log.Printf("[TRACE] go-nitro: FindResourceArrayWithParams: HTTP GET result: %v", string(result))
-	log.Printf("[TRACE] go-nitro: FindResourceArrayWithParams: HTTP GET error: %v", httpErr)
+	c.logger.Trace("FindResourceArrayWithParams: HTTP GET result", "result", string(result), "error", httpErr)
 
 	// Ignore 404.
 	// We need to parse the NITRO errorcode value to determine if this is an actual error
@@ -533,7 +538,7 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 		if !strings.Contains(httpErr.Error(), "404") {
 			return nil, httpErr
 		} else {
-			log.Printf("[DEBUG] go-nitro: FindResourceArrayWithParams: Ignoring 404 http status. %s", httpErr.Error())
+			c.logger.Debug("FindResourceArrayWithParams: Ignoring 404 http status", "error", httpErr.Error())
 		}
 	}
 
@@ -541,7 +546,7 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 
 	err := json.Unmarshal(result, &jsonData)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] go-nitro: FindResourceArrayWithParams: JSON unmarshal error: %s", err.Error())
+		return nil, fmt.Errorf("[ERROR] go-nitro: FindResourceArrayWithParams: JSON unmarshal error %v", err.Error())
 	}
 
 	nitroData, ok := jsonData.(map[string]interface{})
@@ -562,13 +567,13 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 	// Resource missing errorcode returned
 	missingErrcode := findParams.ResourceMissingErrorCode
 	if missingErrcode != 0 && missingErrcode == errorcode {
-		log.Printf("[DEBUG] go-nitro: FindResourceArrayWithParams: resource missing error code returned %d", errorcode)
+		c.logger.Debug("FindResourceArrayWithParams: resource missing error code returned", "errorcode", errorcode)
 		return emptyRetval, nil
 	}
 	// Fallthrough
 
 	if errorcode != 0 {
-		return nil, fmt.Errorf("[ERROR] go-nitro: FindResourceArrayWithParams: non zero errorcode %d", errorcode)
+		return nil, fmt.Errorf("[ERROR] FindResourceArrayWithParams: non zero errorcode %d", errorcode)
 	}
 	// Fallthrough
 
@@ -576,12 +581,12 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 	resourceData, ok := nitroData[findParams.ResourceType]
 	if !ok {
 		// Since errorcode is 0 we persume this is the expected behavior for a missing resource
-		log.Printf("[DEBUG] go-nitro: FindResourceArrayWithParams: resource key missing %s.", findParams.ResourceType)
+		c.logger.Debug("FindResourceArrayWithParams: resource key missing", "resourceType", findParams.ResourceType)
 		return emptyRetval, nil
 	}
 	// Falthrough
 
-	log.Printf("[DEBUG] go-nitro: FindResourceArrayWithParams: retrieved NITRO object: %v", resourceData)
+	c.logger.Trace("FindResourceArrayWithParams: retrieved NITRO object", "resourceData", resourceData)
 
 	// resource data assertion
 	resourceArray, arrayOk := resourceData.([]interface{})
@@ -612,16 +617,16 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 	var data map[string]interface{}
 	result, err := c.listResource(resourceType, "")
 	if err != nil {
-		log.Printf("[INFO] go-nitro: FindAllResources: No %s objects found", resourceType)
+		c.logger.Info(" FindAllResources: No objects found", "resourceType", resourceType)
 		return make([]map[string]interface{}, 0, 0), nil
 	}
 	if err = json.Unmarshal(result, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: FindAllResources: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindAllResources: Failed to unmarshal Netscaler Response!")
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindAllResources: Failed to unmarshal Netscaler Response: of type %s", resourceType)
 	}
 	rsrcs, ok := data[resourceType]
 	if !ok || rsrcs == nil {
-		log.Printf("[INFO] go-nitro: FindAllResources: No %s found", resourceType)
+		c.logger.Info(" FindAllResources: resource not found", "resourceType", resourceType)
 		return make([]map[string]interface{}, 0, 0), nil
 	}
 	resources := data[resourceType].([]interface{})
@@ -638,13 +643,13 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) bool {
 	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
 	if err != nil {
-		log.Printf("[INFO] go-nitro: ResourceBindingExists: No %s %s to %s %s binding found", resourceType, resourceName, boundResourceType, boundResourceFilterValue)
+		c.logger.Info("ResourceBindingExists: No bound resource to found", "resourceType", resourceType, "name", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 		return false
 	}
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(result, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: ResourceBindingExists: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("ResourceBindingExists: Failed to unmarshal Netscaler Response!")
 		return false
 	}
 	binding := fmt.Sprintf("%s_%s_binding", resourceType, boundResourceType)
@@ -653,7 +658,7 @@ func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName st
 		return false
 	}
 
-	log.Printf("[INFO] go-nitro: ResourceBindingExists: %s of type  %s is bound to %s type and name %s", resourceType, resourceName, boundResourceType, boundResourceFilterValue)
+	c.logger.Info("ResourceBindingExists: of type   is bound to  type and name ", "resourceType", resourceType, "resourceName", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 	return true
 }
 
@@ -661,13 +666,13 @@ func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName st
 func (c *NitroClient) FindBoundResource(resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) (map[string]interface{}, error) {
 	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
 	if err != nil {
-		log.Printf("[INFO] go-nitro: FindBoundResource: No %s %s to %s %s binding found", resourceType, resourceName, boundResourceType, boundResourceFilterValue)
+		c.logger.Info(" FindBoundResource: No binding found", "resourceType", resourceType, "resourceName", "resourceName", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 		return nil, fmt.Errorf("[INFO] go-nitro: No %s %s to %s %s binding found, err=%s", resourceType, resourceName, boundResourceType, boundResourceFilterValue, err)
 	}
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(result, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: FindBoundResource: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindBoundResource: Failed to unmarshal Netscaler Response!")
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindBoundResource: Failed to unmarshal Netscaler Response!, err=%s", err)
 	}
 	bindingType := fmt.Sprintf("%s_%s_binding", resourceType, boundResourceType)
@@ -685,13 +690,13 @@ func (c *NitroClient) FindBoundResource(resourceType string, resourceName string
 func (c *NitroClient) FindAllBoundResources(resourceType string, resourceName string, boundResourceType string) ([]map[string]interface{}, error) {
 	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, "", "")
 	if err != nil {
-		log.Printf("[INFO] go-nitro: FindAllBoundResources: No %s %s to %s  binding found", resourceType, resourceName, boundResourceType)
+		c.logger.Info(" FindAllBoundResources: No %s %s to %s  binding found", resourceType, resourceName, boundResourceType)
 		return nil, fmt.Errorf("[ERROR] go-nitro: No %s %s to %s binding found, err=%s", resourceType, resourceName, boundResourceType, err)
 	}
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(result, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: FindAllBoundResources: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindAllBoundResources: Failed to unmarshal Netscaler Response!")
 		return nil, fmt.Errorf("[ERROR] go-nitro: FindAllBoundResources: Failed to unmarshal Netscaler Response!, err=%s", err)
 	}
 	bindingType := fmt.Sprintf("%s_%s_binding", resourceType, boundResourceType)
@@ -725,13 +730,13 @@ func (c *NitroClient) EnableFeatures(featureNames []string) error {
 
 	featureJSON, err := JSONMarshal(featureStruct)
 	if err != nil {
-		log.Printf("[ERROR] go-nitro: EnableFeatures: Failed to marshal features to JSON")
+		c.logger.Error("EnableFeatures: Failed to marshal features to JSON")
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal features to JSON")
 	}
 
 	_, err = c.enableFeatures(featureJSON)
 	if err != nil {
-		return fmt.Errorf("[ERROR] go-nitro: Failed to enable feature %v", err)
+		return fmt.Errorf("[ERROR] Failed to enable feature %v", err)
 	}
 	return nil
 }
@@ -751,7 +756,7 @@ func (c *NitroClient) DisableFeatures(featureNames []string) error {
 
 	featureJSON, err := JSONMarshal(featureStruct)
 	if err != nil {
-		log.Printf("[ERROR] go-nitro: DisableFeatures: Failed to marshal features to JSON")
+		c.logger.Error("DisableFeatures: Failed to marshal features to JSON")
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal features to JSON")
 	}
 
@@ -771,12 +776,12 @@ func (c *NitroClient) ListEnabledFeatures() ([]string, error) {
 	}
 	var data map[string]interface{}
 	if err = json.Unmarshal(bytes, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: FindAllBoundResources: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("FindAllBoundResources: Failed to unmarshal Netscaler Response!")
 		return []string{}, fmt.Errorf("[ERROR] go-nitro: Failed to unmarshal Netscaler Response to list Features")
 	}
 	feat, ok := data["nsfeature"]
 	if !ok || feat == nil {
-		log.Printf("No features found")
+		c.logger.Error("No features found")
 		return []string{}, fmt.Errorf("[ERROR] go-nitro: No features found")
 	}
 
@@ -810,7 +815,7 @@ func (c *NitroClient) EnableModes(modeNames []string) error {
 
 	modeJSON, err := JSONMarshal(modeStruct)
 	if err != nil {
-		log.Printf("[ERROR] go-nitro: EnableModes: Failed to marshal modes to JSON")
+		c.logger.Error("EnableModes: Failed to marshal modes to JSON")
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal modes to JSON")
 	}
 
@@ -830,13 +835,13 @@ func (c *NitroClient) ListEnabledModes() ([]string, error) {
 	}
 	var data map[string]interface{}
 	if err = json.Unmarshal(bytes, &data); err != nil {
-		log.Printf("[ERROR] go-nitro: ListEnabledModes: Failed to unmarshal Netscaler Response!")
+		c.logger.Error("ListEnabledModes: Failed to unmarshal Netscaler Response!")
 		return []string{}, fmt.Errorf("[ERROR] go-nitro: Failed to unmarshal Netscaler Response to list Modes")
 	}
 	mode, ok := data["nsmode"]
 	if !ok || mode == nil {
-		log.Printf("No modes found")
-		return []string{}, fmt.Errorf("[ERROR] go-nitro: No modes found")
+		c.logger.Error("No modes found")
+		return []string{}, fmt.Errorf("[ERROR] No modes found")
 	}
 
 	modes := data["nsmode"].(map[string]interface{})
@@ -865,10 +870,10 @@ func (c *NitroClient) SaveConfig() error {
 
 	saveJSON, err := JSONMarshal(saveStruct)
 	if err != nil {
-		log.Printf("[ERROR] go-nitro: SaveConfig: Failed to marshal save config to JSON")
+		c.logger.Error("SaveConfig: Failed to marshal save config to JSON")
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal save config to JSON")
 	}
-	log.Printf("saveJSON is " + string(saveJSON))
+	c.logger.Debug("saveJSON is " + string(saveJSON))
 
 	err = c.saveConfig(saveJSON)
 	if err != nil {
@@ -891,10 +896,10 @@ func (c *NitroClient) ClearConfig() error {
 
 	clearJSON, err := JSONMarshal(clearStruct)
 	if err != nil {
-		log.Printf("[ERROR] go-nitro: ClearConfig: Failed to marshal clear config to JSON")
+		c.logger.Error("ClearConfig: Failed to marshal clear config to JSON")
 		return fmt.Errorf("[ERROR] go-nitro: Failed to marshal clear config to JSON")
 	}
-	log.Printf("clearJSON is " + string(clearJSON))
+	c.logger.Trace("clearJSON is ", "text", string(clearJSON))
 
 	err = c.clearConfig(clearJSON)
 	if err != nil {

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -56,7 +56,7 @@ func init() {
 	if err != nil {
 		log.Fatal("Could not create a client: ", err)
 	}
-	client.SetLogLevel("DEBUG")
+	client.SetLogLevel("TRACE")
 
 }
 

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -56,6 +56,7 @@ func init() {
 	if err != nil {
 		log.Fatal("Could not create a client: ", err)
 	}
+	client.SetLogLevel("DEBUG")
 
 }
 

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -56,7 +56,7 @@ func init() {
 	if err != nil {
 		log.Fatal("Could not create a client: ", err)
 	}
-	client.SetLogLevel("TRACE")
+	client.SetLogLevel("INFO")
 
 }
 
@@ -89,7 +89,7 @@ func TestAdd(t *testing.T) {
 	_, err := client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not add Lbvserver: ", err)
-		log.Println("Not continuing test")
+		t.Log("Not continuing test")
 		return
 	}
 
@@ -148,7 +148,7 @@ func TestApply(t *testing.T) {
 	_, err := client.AddResource(Nsacl.Type(), aclName, &acl1)
 	if err != nil {
 		t.Error("Could not add resource Nsacl", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -161,7 +161,7 @@ func TestApply(t *testing.T) {
 	}
 	if err == nil {
 		acl2 := readAcls[0]
-		log.Println("Found acl, kernelstate= ", acl2["kernelstate"])
+		t.Log("Found acl, kernelstate= ", acl2["kernelstate"])
 		if acl2["kernelstate"].(string) != "APPLIED" {
 			t.Error("ACL created but not APPLIED ", Nsacl.Type(), ":", aclName)
 		}
@@ -182,7 +182,7 @@ func TestUpdate(t *testing.T) {
 	_, err := client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not create LB", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -193,13 +193,13 @@ func TestUpdate(t *testing.T) {
 	_, err = client.UpdateResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not update LB")
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	rsrc, err := client.FindResource(Lbvserver.Type(), lbName)
 	if err != nil {
 		t.Error("Did not find resource of type ", Lbvserver.Type(), ":", lbName, err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	val, ok := rsrc["lbmethod"]
@@ -229,7 +229,7 @@ func TestBindUnBind(t *testing.T) {
 	_, err := client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not create LB", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	service1 := basic.Service{
@@ -242,7 +242,7 @@ func TestBindUnBind(t *testing.T) {
 	_, err = client.AddResource(Service.Type(), svcName, &service1)
 	if err != nil {
 		t.Error("Could not create service", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -254,19 +254,19 @@ func TestBindUnBind(t *testing.T) {
 	err = client.BindResource(Lbvserver.Type(), lbName, Service.Type(), svcName, &binding)
 	if err != nil {
 		t.Error("Could not bind LB to svc", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	exists := client.ResourceBindingExists(Lbvserver.Type(), lbName, Service.Type(), "servicename", svcName)
 	if !exists {
 		t.Error("Failed to bind service to lb vserver")
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	err = client.UnbindResource(Lbvserver.Type(), lbName, Service.Type(), svcName, "servicename")
 	if err != nil {
 		t.Error("Could not unbind LB to svc", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	exists = client.ResourceBindingExists(Lbvserver.Type(), lbName, Service.Type(), "servicename", svcName)
@@ -288,7 +288,7 @@ func TestFindBoundResource(t *testing.T) {
 	_, err := client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Failed to add resource of type ", Lbvserver.Type(), ":", "sample_lb_1", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	svcName := "test_svc_" + randomString(5)
@@ -302,7 +302,7 @@ func TestFindBoundResource(t *testing.T) {
 	_, err = client.AddResource(Service.Type(), svcName, &service1)
 	if err != nil {
 		t.Error("Failed to add resource of type ", Service.Type(), ":", svcName, err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 
 	}
@@ -313,18 +313,18 @@ func TestFindBoundResource(t *testing.T) {
 	err = client.BindResource(Lbvserver.Type(), lbName, Service.Type(), svcName, &binding)
 	if err != nil {
 		t.Error("Failed to bind resource of type ", Service.Type(), ":", svcName)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 
 	}
 	result, err := client.FindBoundResource(Lbvserver.Type(), lbName, Service.Type(), "servicename", svcName)
 	if err != nil {
 		t.Error("Failed to find bound resource of type ", Service.Type(), ":", svcName)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 
 	}
-	//log.Println("Found bound resource ", result)
+	//t.Log("Found bound resource ", result)
 	if result["servicename"] != svcName {
 		t.Error("Failed to find bound resource of type ", Service.Type(), ":", svcName)
 	}
@@ -345,14 +345,14 @@ func TestDelete(t *testing.T) {
 	_, err := client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not create LB", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
 	err = client.DeleteResource(Lbvserver.Type(), lbName)
 	if err != nil {
 		t.Error("Could not delete LB", lbName, err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	if client.ResourceExists(Lbvserver.Type(), lbName) {
@@ -373,7 +373,7 @@ func TestDeleteWithArgs(t *testing.T) {
 	_, err := client.AddResource(Lbmonitor.Type(), monitorName, &lbmonitor)
 	if err != nil {
 		t.Error("Could not create monitor", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -381,7 +381,7 @@ func TestDeleteWithArgs(t *testing.T) {
 	err = client.DeleteResourceWithArgsMap(Lbmonitor.Type(), monitorName, args)
 	if err != nil {
 		t.Error("Could not delete monitor", monitorName, err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 }
@@ -391,13 +391,13 @@ func TestEnableFeatures(t *testing.T) {
 	err := client.EnableFeatures(features)
 	if err != nil {
 		t.Error("Failed to enable features", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	result, err := client.ListEnabledFeatures()
 	if err != nil {
 		t.Error("Failed to retrieve features", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	found := 0
@@ -418,13 +418,13 @@ func TestEnableModes(t *testing.T) {
 	err := client.EnableModes(modes)
 	if err != nil {
 		t.Error("Failed to enable modes", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	result, err := client.ListEnabledModes()
 	if err != nil {
 		t.Error("Failed to retrieve modes", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	found := 0
@@ -467,13 +467,13 @@ func TestFindAllResources(t *testing.T) {
 	_, err := client.AddResource(Lbvserver.Type(), lbName1, &lb1)
 	if err != nil {
 		t.Error("Failed to add resource of type ", Lbvserver.Type(), ":", lbName1)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	_, err = client.AddResource(Lbvserver.Type(), lbName2, &lb2)
 	if err != nil {
 		t.Error("Failed to add resource of type ", Lbvserver.Type(), ":", lbName2)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	rsrcs, err := client.FindAllResources(Lbvserver.Type())
@@ -528,13 +528,13 @@ func TestFindAllBoundResources(t *testing.T) {
 	_, err = client.AddResource(Service.Type(), svcName1, &service1)
 	if err != nil {
 		t.Error("Could not create service service1", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	_, err = client.AddResource(Service.Type(), svcName2, &service2)
 	if err != nil {
 		t.Error("Could not create service service2", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -550,14 +550,14 @@ func TestFindAllBoundResources(t *testing.T) {
 	err = client.BindResource(Lbvserver.Type(), lbName1, Service.Type(), svcName1, &binding1)
 	if err != nil {
 		t.Error("Could not bind service service1")
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
 	err = client.BindResource(Lbvserver.Type(), lbName1, Service.Type(), svcName2, &binding2)
 	if err != nil {
 		t.Error("Could not bind service service2")
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	rsrcs, err := client.FindAllBoundResources(Lbvserver.Type(), lbName1, Service.Type())
@@ -566,7 +566,7 @@ func TestFindAllBoundResources(t *testing.T) {
 	}
 	if len(rsrcs) < 2 {
 		t.Error("Found only ", len(rsrcs), " resources of type ", Service.Type(), " expected at least 2")
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -593,7 +593,7 @@ func TestAction(t *testing.T) {
 	_, err := client.AddResource(Servicegroup.Type(), svcGrpName, &sg1)
 	if err != nil {
 		t.Error("Could not add resource service group", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	createServer := basic.Server{
@@ -604,7 +604,7 @@ func TestAction(t *testing.T) {
 	_, err = client.AddResource(Server.Type(), "test-server", &createServer)
 	if err != nil {
 		t.Error("Could not add resource server", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -617,7 +617,7 @@ func TestAction(t *testing.T) {
 	_, err = client.AddResource(Servicegroup_servicegroupmember_binding.Type(), "test-svcgroup", &bindSvcGrpToServer)
 	if err != nil {
 		t.Error("Could not bind resource server", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -630,7 +630,7 @@ func TestAction(t *testing.T) {
 	_, err = client.AddResource(Servicegroup_servicegroupmember_binding.Type(), "test-svcgroup", &bindSvcGrpToServer2)
 	if err != nil {
 		t.Error("Could not bind resource server", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	sg2 := basic.Servicegroup{
@@ -645,7 +645,7 @@ func TestAction(t *testing.T) {
 
 	if err != nil {
 		t.Error("Could not disable server", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	sg3 := basic.Servicegroup{
@@ -658,7 +658,7 @@ func TestAction(t *testing.T) {
 
 	if err != nil {
 		t.Error("Could not enable server", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -671,13 +671,16 @@ func TestAction(t *testing.T) {
 
 	if err != nil {
 		t.Error("Could not rename servicegroup", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
 }
 
 func TestUpdateUnnamedResource(t *testing.T) {
+	if os.Getenv("ADC_PLATFORM") == "CPX" {
+		t.Skip("Skipping test not supported by CPX")
+	}
 	rnat := network.Rnat{
 		Natip:   "172.17.0.2",
 		Netmask: "255.255.240.0",
@@ -687,12 +690,15 @@ func TestUpdateUnnamedResource(t *testing.T) {
 	err := client.UpdateUnnamedResource(Rnat.Type(), &rnat)
 	if err != nil {
 		t.Error("Could not add Rnat", err)
-		log.Println("Cannot continue")
+		//t.Log("Cannot continue")
 		return
 	}
 }
 
 func TestFindFilteredResource(t *testing.T) {
+	if os.Getenv("ADC_PLATFORM") == "CPX" {
+		t.Skip("Skipping test not supported by CPX")
+	}
 	rnat := network.Rnat{
 		Natip:   "172.17.0.2",
 		Netmask: "255.255.240.0",
@@ -702,13 +708,13 @@ func TestFindFilteredResource(t *testing.T) {
 	err := client.UpdateUnnamedResource(Rnat.Type(), &rnat)
 	if err != nil {
 		t.Error("Could not add Rnat", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	d, err := client.FindFilteredResourceArray(Rnat.Type(), map[string]string{"network": "192.168.16.0", "netmask": "255.255.240.0", "natip": "172.17.0.2"})
 	if err != nil {
 		t.Error("Could not find Rnat", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	if len(d) != 1 {
@@ -736,7 +742,7 @@ func TestDesiredStateServicegroupAPI(t *testing.T) {
 	_, err := client.AddResource(Servicegroup.Type(), svcGrpName, &sg1)
 	if err != nil {
 		t.Error("Could not add resource autoscale service group", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -763,13 +769,16 @@ func TestDesiredStateServicegroupAPI(t *testing.T) {
 	_, err = client.AddResource(Servicegroup_servicegroupmemberlist_binding.Type(), "test-svcgroup", &bindSvcGrpToServer)
 	if err != nil {
 		t.Error("Could not bind resource server", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
 }
 
 func TestNullAction(t *testing.T) {
+	if os.Getenv("ADC_PLATFORM") == "CPX" {
+		t.Skip("Skipping test not supported by CPX")
+	}
 	reboot := ns.Reboot{
 		Warm: true,
 	}
@@ -777,7 +786,7 @@ func TestNullAction(t *testing.T) {
 	err := client.ActOnResource("reboot", &reboot, "")
 	if err != nil {
 		t.Error("Could not make null action reboot", err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 
@@ -805,7 +814,7 @@ func TestTokenBasedAuth(t *testing.T) {
 	_, err = client.AddResource(Lbvserver.Type(), lbName, &lb1)
 	if err != nil {
 		t.Error("Could not add Lbvserver: ", err)
-		log.Println("Not continuing test")
+		t.Log("Not continuing test")
 		return
 	}
 
@@ -813,12 +822,12 @@ func TestTokenBasedAuth(t *testing.T) {
 	if err != nil {
 		t.Error("Did not find resource of type ", err, Lbvserver.Type(), ":", lbName)
 	} else {
-		log.Println("LB-METHOD: ", rsrc["lbmethod"])
+		t.Log("LB-METHOD: ", rsrc["lbmethod"])
 	}
 	err = client.DeleteResource(Lbvserver.Type(), lbName)
 	if err != nil {
 		t.Error("Could not delete LB", lbName, err)
-		log.Println("Cannot continue")
+		t.Log("Cannot continue")
 		return
 	}
 	err = client.Logout()
@@ -837,7 +846,7 @@ func TestTokenBasedAuth(t *testing.T) {
 			t.Error("Sessionid not cleared")
 			return
 		}
-		log.Println("sessionid cleared because of session-expiry")
+		t.Log("sessionid cleared because of session-expiry")
 	} else {
 		t.Error("Adding lbvserver should have failed because of session-expiry")
 	}

--- a/netscaler/config_test.go
+++ b/netscaler/config_test.go
@@ -53,10 +53,14 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 	var err error
 	client, err = NewNitroClientFromEnv()
+
 	if err != nil {
 		log.Fatal("Could not create a client: ", err)
 	}
-	client.SetLogLevel("INFO")
+	_, ok := os.LookupEnv("NITRO_LOG") //if NITRO_LOG has been set then let the client get it from the environment
+	if !ok {
+		client.SetLogLevel("INFO")
+	}
 
 }
 

--- a/netscaler/netscaler_resource.go
+++ b/netscaler/netscaler_resource.go
@@ -100,7 +100,7 @@ func readResponseHandler(resp *http.Response, logger hclog.Logger) ([]byte, erro
 		return body, nil
 	case "404 Not Found":
 		body, _ := ioutil.ReadAll(resp.Body)
-		logger.Debug("read: 404 not found")
+		logger.Debug("readResponseHandler: 404 not found")
 		return body, errors.New("read: 404 not found: ")
 	case "400 Bad Request", "401 Unauthorized", "403 Forbidden",
 		"405 Method Not Allowed", "406 Not Acceptable",
@@ -233,7 +233,7 @@ func (c *NitroClient) actOnResource(resourceType string, resourceJSON []byte, ac
 	} else {
 		url = c.url + fmt.Sprintf("%s?action=%s", resourceType, action)
 	}
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("actOnResource ", "url", url)
 
 	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
@@ -243,7 +243,7 @@ func (c *NitroClient) changeResource(resourceType string, resourceName string, r
 	c.logger.Trace("changing resource", "resourceType", resourceType)
 
 	url := c.url + resourceType + "/" + resourceName + "?action=update"
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("changeResource", "url", url)
 
 	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
@@ -253,7 +253,7 @@ func (c *NitroClient) updateResource(resourceType string, resourceName string, r
 	c.logger.Trace("Updating resource ", "resourceType", resourceType)
 
 	url := c.url + resourceType + "/" + resourceName
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("updateResource ", "url", url)
 
 	return c.doHTTPRequest("PUT", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
@@ -263,7 +263,7 @@ func (c *NitroClient) updateUnnamedResource(resourceType string, resourceJSON []
 	c.logger.Trace("Updating unnamed resource", "resourceType", resourceType)
 
 	url := c.url + resourceType
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("updateUnnamedResource", "url", url)
 
 	return c.doHTTPRequest("PUT", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
@@ -277,7 +277,7 @@ func (c *NitroClient) deleteResource(resourceType string, resourceName string) (
 	} else {
 		url = c.url + fmt.Sprintf("%s", resourceType)
 	}
-	c.logger.Trace("url is ", url)
+	c.logger.Trace("deleteResource", "url", url)
 
 	return c.doHTTPRequest("DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
 
@@ -292,7 +292,7 @@ func (c *NitroClient) deleteResourceWithArgs(resourceType string, resourceName s
 		url = c.url + fmt.Sprintf("%s?args=", resourceType)
 	}
 	url = url + strings.Join(args, ",")
-	c.logger.Trace("url is ", url)
+	c.logger.Trace("deleteResourceWithArgs ", "url", url)
 
 	return c.doHTTPRequest("DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
 
@@ -355,7 +355,7 @@ func (c *NitroClient) listResource(resourceType string, resourceName string) ([]
 	if resourceName != "" {
 		url = c.url + fmt.Sprintf("%s/%s", resourceType, resourceName)
 	}
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("listResource", "url", url)
 
 	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
@@ -372,12 +372,13 @@ func (c *NitroClient) listResourceWithArgs(resourceType string, resourceName str
 	}
 	strArgs := strings.Join(args, ",")
 	url2 := url + "?args=" + strArgs
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("listResourceWithArgs", "url", url)
 
 	data, err := c.doHTTPRequest("GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
 	if err != nil {
-		c.logger.Trace("error listing with args, trying filter")
+		c.logger.Trace("listResourceWithArgs: error listing with args, trying filter", "error", err)
 		url2 = url + "?filter=" + strArgs
+		c.logger.Trace("listResourceWithArgs", "url2", url2)
 		return c.doHTTPRequest("GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
 	}
 	return data, err
@@ -459,7 +460,7 @@ func (c *NitroClient) listStat(resourceType, resourceName string) ([]byte, error
 	if resourceName != "" {
 		url = c.statsURL + fmt.Sprintf("%s/%s", resourceType, resourceName)
 	}
-	c.logger.Trace("url is ", url)
+	c.logger.Trace("listStat", "url", url)
 
 	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
@@ -476,7 +477,7 @@ func (c *NitroClient) listStatWithArgs(resourceType string, resourceName string,
 	}
 	strArgs := strings.Join(args, ",")
 	url = url + "?args=" + strArgs
-	c.logger.Trace("url is ", "url", url)
+	c.logger.Trace("listStatWithArgs", "url", url)
 
 	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 }


### PR DESCRIPTION
This should ease usage of this library since otherwise it is too verbose for non-Terraform use cases. 
With this change, logging can be controlled in 2 ways
environment variable (NITRO_LOG=TRACE|DEBUG|INFO|WARN|ERROR|OFF)
or client.setLogLevel("<value")
Default is OFF. 
All logs have been changed to use the Key,value format of hclog. 
We can even turn on JSON logging using hclog